### PR TITLE
Add test.Err and clean up tests

### DIFF
--- a/test.go
+++ b/test.go
@@ -55,6 +55,14 @@ func Ok(t testing.TB, err error) {
 	}
 }
 
+// Err fails if err == nil.
+func Err(t testing.TB, err error) {
+	t.Helper()
+	if err == nil {
+		t.Fatalf("Error was not nil:\t%v\n", err)
+	}
+}
+
 // True fails if v is false.
 func True(t testing.TB, v bool) {
 	t.Helper()

--- a/test_test.go
+++ b/test_test.go
@@ -45,59 +45,52 @@ func TestPass(t *testing.T) {
 		}
 	}
 
-	shouldPass(func(tb testing.TB) { test.Equal(tb, "hello", "hello") })
-	shouldPass(func(tb testing.TB) { test.Equal(tb, 42, 42) })
-	shouldPass(func(tb testing.TB) { test.Equal(tb, true, true) })
-	shouldPass(func(tb testing.TB) { test.Equal(tb, 3.14, 3.14) })
+	// All functions that should not fail their test TB
+	passFns := []func(tb testing.TB){
+		func(tb testing.TB) { test.Equal(tb, "hello", "hello") },
+		func(tb testing.TB) { test.Equal(tb, "hello", "hello") },
+		func(tb testing.TB) { test.Equal(tb, 42, 42) },
+		func(tb testing.TB) { test.Equal(tb, true, true) },
+		func(tb testing.TB) { test.Equal(tb, 3.14, 3.14) },
+		func(tb testing.TB) { test.NotEqual(tb, "hello", "there") },
+		func(tb testing.TB) { test.NotEqual(tb, 42, 27) },
+		func(tb testing.TB) { test.NotEqual(tb, true, false) },
+		func(tb testing.TB) { test.NotEqual(tb, 3.14, 8.67) },
+		func(tb testing.TB) { test.Ok(tb, nil) },
+		func(tb testing.TB) { test.Err(tb, errors.New("uh oh")) },
+		func(tb testing.TB) { test.True(tb, true) },
+		func(tb testing.TB) { test.False(tb, false) },
+		func(tb testing.TB) { test.Diff(tb, 42, 42) },
+		func(tb testing.TB) { test.Diff(tb, true, true) },
+		func(tb testing.TB) { test.Diff(tb, "hello", "hello") },
+		func(tb testing.TB) { test.Diff(tb, 3.14, 3.14) },
+		func(tb testing.TB) { test.Diff(tb, []string{"hello"}, []string{"hello"}) },
+		func(tb testing.TB) {
+			test.EqualFunc(tb, "something", "equal", func(got, want string) bool { return true })
+		},
+		func(tb testing.TB) { test.EqualFunc(tb, 42, 42, func(got, want int) bool { return true }) },
+		func(tb testing.TB) {
+			test.EqualFunc(tb, []string{"hello"}, []string{"hello"}, func(got, want []string) bool { return true })
+		},
+		func(tb testing.TB) {
+			test.NotEqualFunc(tb, "something", "different", func(got, want string) bool { return false })
+		},
+		func(tb testing.TB) { test.NotEqualFunc(tb, 42, 12, func(got, want int) bool { return false }) },
+		func(tb testing.TB) {
+			test.NotEqualFunc(tb, []string{"hello"}, []string{"something", "else"}, func(got, want []string) bool { return false })
+		},
+		func(tb testing.TB) {
+			test.Diff(tb, struct{ name string }{name: "dave"}, struct{ name string }{name: "dave"})
+		},
+		func(tb testing.TB) {
+			test.Diff(tb, struct{ Name string }{Name: "dave"}, struct{ Name string }{Name: "dave"})
+		},
+		func(tb testing.TB) { test.DeepEqual(tb, []string{"hello"}, []string{"hello"}) },
+	}
 
-	shouldPass(func(tb testing.TB) { test.NotEqual(tb, "hello", "there") })
-	shouldPass(func(tb testing.TB) { test.NotEqual(tb, 42, 27) })
-	shouldPass(func(tb testing.TB) { test.NotEqual(tb, true, false) })
-	shouldPass(func(tb testing.TB) { test.NotEqual(tb, 3.14, 8.67) })
-
-	shouldPass(func(tb testing.TB) { test.Ok(tb, nil) })
-
-	shouldPass(func(tb testing.TB) { test.True(tb, true) })
-	shouldPass(func(tb testing.TB) { test.False(tb, false) })
-
-	shouldPass(func(tb testing.TB) {
-		test.EqualFunc(tb, "something", "equal", func(got, want string) bool { return true })
-	})
-
-	shouldPass(func(tb testing.TB) {
-		test.EqualFunc(tb, 42, 42, func(got, want int) bool { return true })
-	})
-
-	shouldPass(func(tb testing.TB) {
-		test.EqualFunc(tb, []string{"hello"}, []string{"hello"}, func(got, want []string) bool { return true })
-	})
-
-	shouldPass(func(tb testing.TB) {
-		test.NotEqualFunc(tb, "something", "different", func(got, want string) bool { return false })
-	})
-
-	shouldPass(func(tb testing.TB) {
-		test.NotEqualFunc(tb, 42, 12, func(got, want int) bool { return false })
-	})
-
-	shouldPass(func(tb testing.TB) {
-		test.NotEqualFunc(tb, []string{"hello"}, []string{"something", "else"}, func(got, want []string) bool { return false })
-	})
-
-	shouldPass(func(tb testing.TB) { test.Diff(tb, "hello", "hello") })
-	shouldPass(func(tb testing.TB) { test.Diff(tb, 42, 42) })
-	shouldPass(func(tb testing.TB) { test.Diff(tb, true, true) })
-	shouldPass(func(tb testing.TB) { test.Diff(tb, 3.14, 3.14) })
-	shouldPass(func(tb testing.TB) { test.Diff(tb, []string{"hello"}, []string{"hello"}) })
-
-	shouldPass(func(tb testing.TB) {
-		test.Diff(tb, struct{ name string }{name: "dave"}, struct{ name string }{name: "dave"})
-	})
-	shouldPass(func(tb testing.TB) {
-		test.Diff(tb, struct{ Name string }{Name: "dave"}, struct{ Name string }{Name: "dave"})
-	})
-
-	shouldPass(func(tb testing.TB) { test.DeepEqual(tb, []string{"hello"}, []string{"hello"}) })
+	for _, fn := range passFns {
+		shouldPass(fn)
+	}
 }
 
 func TestFail(t *testing.T) {
@@ -122,57 +115,54 @@ func TestFail(t *testing.T) {
 		}
 	}
 
-	shouldFail(func(tb testing.TB) { test.Equal(tb, "something", "else") })
-	shouldFail(func(tb testing.TB) { test.Equal(tb, 42, 27) })
-	shouldFail(func(tb testing.TB) { test.Equal(tb, true, false) })
-	shouldFail(func(tb testing.TB) { test.Equal(tb, 3.14, 8.96) })
+	failFns := []func(tb testing.TB){
+		func(tb testing.TB) { test.Equal(tb, "something", "else") },
+		func(tb testing.TB) { test.Equal(tb, 42, 27) },
+		func(tb testing.TB) { test.Equal(tb, true, false) },
+		func(tb testing.TB) { test.Equal(tb, 3.14, 8.96) },
+		func(tb testing.TB) { test.NotEqual(tb, "something", "something") },
+		func(tb testing.TB) { test.NotEqual(tb, 42, 42) },
+		func(tb testing.TB) { test.NotEqual(tb, true, true) },
+		func(tb testing.TB) { test.NotEqual(tb, 3.14, 3.14) },
+		func(tb testing.TB) { test.Ok(tb, errors.New("uh oh")) },
+		func(tb testing.TB) { test.Err(tb, nilErr()) },
+		func(tb testing.TB) { test.True(tb, false) },
+		func(tb testing.TB) { test.False(tb, true) },
+		func(tb testing.TB) { test.Diff(tb, "hello", "there") },
+		func(tb testing.TB) { test.Diff(tb, 42, 27) },
+		func(tb testing.TB) { test.Diff(tb, true, false) },
+		func(tb testing.TB) { test.Diff(tb, 3.14, 8.69) },
+		func(tb testing.TB) { test.Diff(tb, []string{"hello"}, []string{"there"}) },
+		func(tb testing.TB) {
+			test.EqualFunc(tb, "something", "different", func(got, want string) bool { return false })
+		},
+		func(tb testing.TB) { test.EqualFunc(tb, 42, 127, func(got, want int) bool { return false }) },
+		func(tb testing.TB) {
+			test.EqualFunc(tb, []int{42}, []int{27}, func(got, want []int) bool { return false })
+		},
+		func(tb testing.TB) {
+			test.NotEqualFunc(tb, "something", "something", func(got, want string) bool { return true })
+		},
+		func(tb testing.TB) { test.NotEqualFunc(tb, 42, 42, func(got, want int) bool { return true }) },
+		func(tb testing.TB) {
+			test.NotEqualFunc(tb, []int{42}, []int{42}, func(got, want []int) bool { return true })
+		},
+		func(tb testing.TB) {
+			test.Diff(tb, struct{ name string }{name: "dave"}, struct{ name string }{name: "john"})
+		},
+		func(tb testing.TB) {
+			test.Diff(tb, struct{ Name string }{Name: "dave"}, struct{ Name string }{Name: "john"})
+		},
+		func(tb testing.TB) { test.DeepEqual(tb, []string{"hello"}, []string{"world"}) },
+	}
 
-	shouldFail(func(tb testing.TB) { test.NotEqual(tb, "something", "something") })
-	shouldFail(func(tb testing.TB) { test.NotEqual(tb, 42, 42) })
-	shouldFail(func(tb testing.TB) { test.NotEqual(tb, true, true) })
-	shouldFail(func(tb testing.TB) { test.NotEqual(tb, 3.14, 3.14) })
+	for _, fn := range failFns {
+		shouldFail(fn)
+	}
+}
 
-	shouldFail(func(tb testing.TB) { test.Ok(tb, errors.New("uh oh")) })
-
-	shouldFail(func(tb testing.TB) { test.True(tb, false) })
-	shouldFail(func(tb testing.TB) { test.False(tb, true) })
-
-	shouldFail(func(tb testing.TB) {
-		test.EqualFunc(tb, "something", "different", func(got, want string) bool { return false })
-	})
-
-	shouldFail(func(tb testing.TB) {
-		test.EqualFunc(tb, 42, 127, func(got, want int) bool { return false })
-	})
-
-	shouldFail(func(tb testing.TB) {
-		test.EqualFunc(tb, []int{42}, []int{27}, func(got, want []int) bool { return false })
-	})
-
-	shouldFail(func(tb testing.TB) {
-		test.NotEqualFunc(tb, "something", "something", func(got, want string) bool { return true })
-	})
-
-	shouldFail(func(tb testing.TB) {
-		test.NotEqualFunc(tb, 42, 42, func(got, want int) bool { return true })
-	})
-
-	shouldFail(func(tb testing.TB) {
-		test.NotEqualFunc(tb, []int{42}, []int{42}, func(got, want []int) bool { return true })
-	})
-
-	shouldFail(func(tb testing.TB) { test.Diff(tb, "hello", "there") })
-	shouldFail(func(tb testing.TB) { test.Diff(tb, 42, 27) })
-	shouldFail(func(tb testing.TB) { test.Diff(tb, true, false) })
-	shouldFail(func(tb testing.TB) { test.Diff(tb, 3.14, 8.69) })
-	shouldFail(func(tb testing.TB) { test.Diff(tb, []string{"hello"}, []string{"there"}) })
-
-	shouldFail(func(tb testing.TB) {
-		test.Diff(tb, struct{ name string }{name: "dave"}, struct{ name string }{name: "john"})
-	})
-	shouldFail(func(tb testing.TB) {
-		test.Diff(tb, struct{ Name string }{Name: "dave"}, struct{ Name string }{Name: "john"})
-	})
-
-	shouldFail(func(tb testing.TB) { test.DeepEqual(tb, []string{"hello"}, []string{"world"}) })
+// Always returns a nil error, needed because manually constructing
+// nil means it's not an error type but here it is.
+func nilErr() error {
+	return nil
 }


### PR DESCRIPTION
<!-- Provide a brief summary of your changes in the Title above -->

#### Description
<!-- Describe your changes in detail -->
Adds a public function `test.Err` that fails if the provided `err` is equal to `nil`. effectively the opposite of `test.Ok`

Also refactored the tests to be neater and call `shouldPass` or `shouldFail` in a loop

#### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->
Closes #

#### How Has This Been Tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->

#### Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have updated the documentation if needed.
- [x] I have updated the tests if needed.
