### PR TITLE
Fix order of arguments passed to File

### DIFF
--- a/test.go
+++ b/test.go
@@ -193,17 +193,17 @@ func Data(t testing.TB) string {
 	return filepath.Join(cwd, "testdata")
 }
 
-// File fails if the contents of the given file do not match want.
+// File fails if got does not match the contents of the given file.
 //
-// It takes the name of a file (relative to $CWD/testdata) and the contents to compare.
+// It takes a string and the name of a file (relative to $CWD/testdata) to compare.
 //
 // If the contents differ, the test will fail with output equivalent to [Diff].
 //
 // Files with differing line endings (e.g windows CR LF \r\n vs unix LF \n) will be normalised to
 // \n prior to comparison so this function will behave identically across multiple platforms.
 //
-//	test.File(t, "expected.txt", "hello\n")
-func File(t testing.TB, file, want string) {
+//	test.File(t, "hello\n", "expected.txt")
+func File(t testing.TB, got, file string) {
 	t.Helper()
 	file = filepath.Join(Data(t), file)
 	contents, err := os.ReadFile(file)
@@ -213,7 +213,7 @@ func File(t testing.TB, file, want string) {
 
 	contents = bytes.ReplaceAll(contents, []byte("\r\n"), []byte("\n"))
 
-	Diff(t, string(contents), want)
+	Diff(t, got, string(contents))
 }
 
 // CaptureOutput captures and returns data printed to stdout and stderr by the provided function fn, allowing

--- a/test_test.go
+++ b/test_test.go
@@ -106,7 +106,7 @@ func TestPass(t *testing.T) {
 		"DeepEqual string slice": func(tb testing.TB) { test.DeepEqual(tb, []string{"hello"}, []string{"hello"}) },
 		"WantErr true":           func(tb testing.TB) { test.WantErr(tb, errors.New("uh oh"), true) },
 		"WantErr false":          func(tb testing.TB) { test.WantErr(tb, nilErr(), false) },
-		"File":                   func(tb testing.TB) { test.File(tb, "file.txt", "hello\n") },
+		"File":                   func(tb testing.TB) { test.File(tb, "hello\n", "file.txt") },
 	}
 
 	for name, fn := range passFns {
@@ -181,8 +181,8 @@ func TestFail(t *testing.T) {
 		"DeepEqual string slice": func(tb testing.TB) { test.DeepEqual(tb, []string{"hello"}, []string{"world"}) },
 		"WantErr true":           func(tb testing.TB) { test.WantErr(tb, errors.New("uh oh"), false) },
 		"WantErr false":          func(tb testing.TB) { test.WantErr(tb, nilErr(), true) },
-		"File wrong":             func(tb testing.TB) { test.File(tb, "file.txt", "wrong\n") },
-		"File missing":           func(tb testing.TB) { test.File(tb, "missing.txt", "wrong\n") },
+		"File wrong":             func(tb testing.TB) { test.File(tb, "wrong\n", "file.txt") },
+		"File missing":           func(tb testing.TB) { test.File(tb, "wrong\n", "missing.txt") },
 	}
 
 	for name, fn := range failFns {


### PR DESCRIPTION
<!-- Provide a brief summary of your changes in the Title above -->

#### Description
<!-- Describe your changes in detail -->
Rearranges the arguments to `test.File` to make a bit more sense:

Instead of `test.File(t, "file.txt", "contents")`

It is now `test.File(t, "contents", "file.txt")`

#### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->
Closes #

#### How Has This Been Tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->

#### Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have updated the documentation if needed.
- [ ] I have updated the tests if needed.
