### PR TITLE
Colourise diffs in `test.File`

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,2 @@
+ignore:
+  - internal

--- a/internal/colour/colour.go
+++ b/internal/colour/colour.go
@@ -1,0 +1,33 @@
+// Package colour implements basic text colouring for showing text diffs.
+package colour
+
+// ANSI codes for coloured output, they are all the same length so as not to throw off
+// alignment of [text/tabwriter].
+const (
+	codeRed    = "\x1b[0;0031m" // Red, used for diff lines starting with '-'
+	codeHeader = "\x1b[1;0036m" // Bold cyan, used for diff headers starting with '@@'
+	codeGreen  = "\x1b[0;0032m" // Green, used for diff lines starting with '+'
+	codeReset  = "\x1b[000000m" // Reset all attributes
+)
+
+// Header returns a diff header styled string.
+func Header(text string) string {
+	return sprint(codeHeader, text)
+}
+
+// Green returns a green styled string.
+func Green(text string) string {
+	return sprint(codeGreen, text)
+}
+
+// Red returns a red styled string.
+func Red(text string) string {
+	return sprint(codeRed, text)
+}
+
+// sprint returns a string with a given colour and the reset code.
+//
+// It handles checking for NO_COLOR and FORCE_COLOR.
+func sprint(code, text string) string {
+	return code + text + codeReset
+}

--- a/test.go
+++ b/test.go
@@ -17,6 +17,7 @@ import (
 	"sync"
 	"testing"
 
+	"github.com/FollowTheProcess/test/internal/colour"
 	"github.com/aymanbagabas/go-udiff"
 	"github.com/google/go-cmp/cmp"
 )
@@ -333,8 +334,8 @@ func File(tb testing.TB, got, file string) {
 
 	contents = bytes.ReplaceAll(contents, []byte("\r\n"), []byte("\n"))
 
-	if diff := udiff.Unified("want", "got", string(contents), got); diff != "" {
-		tb.Fatalf("\nMismatch\n--------\n%s\n", diff)
+	if diff := udiff.Unified(f, "got", string(contents), got); diff != "" {
+		tb.Fatalf("\nMismatch\n--------\n%s\n", prettyDiff(diff))
 	}
 }
 
@@ -466,4 +467,27 @@ func getComment() string {
 
 	// Didn't find one
 	return ""
+}
+
+// prettyDiff takes a string diff in unified diff format and colourises it for easier viewing.
+func prettyDiff(diff string) string {
+	// TODO(@FollowTheProcess): I don't like parsing the string directly but
+	// it's the simplest way I think
+	lines := strings.Split(diff, "\n")
+	for i := 0; i < len(lines); i++ {
+		trimmed := strings.TrimSpace(lines[i])
+		if strings.HasPrefix(trimmed, "---") || strings.HasPrefix(trimmed, "- ") {
+			lines[i] = colour.Red(lines[i])
+		}
+
+		if strings.HasPrefix(trimmed, "@@") {
+			lines[i] = colour.Header(lines[i])
+		}
+
+		if strings.HasPrefix(trimmed, "+++") || strings.HasPrefix(trimmed, "+ ") {
+			lines[i] = colour.Green(lines[i])
+		}
+	}
+
+	return strings.Join(lines, "\n")
 }


### PR DESCRIPTION
## Summary

<!-- Describe your changes in detail here, if it closes an open issue, include "Closes #<issue>" -->
Does rudimentary colourisation in the diff produced by `test.File` to make it easier to parse, this does not respect `$NO_COLOR` or `$FORCE_COLOR`

Now looks like this:

<img width="695" alt="image" src="https://github.com/user-attachments/assets/f144c7c9-96c7-471f-9493-afa04b21818c">

